### PR TITLE
Fix CI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,12 @@
 version: 2
 
 jobs:
-  build__CONDA_PERL_5.22.2.1:
+  build__CONDA_PERL_5.22.2.1__CONDA_PY_27:
     working_directory: ~/test
     machine: true
     environment:
       - CONDA_PERL: "5.22.2.1"
+      - CONDA_PY: "27"
     steps:
       - checkout
       - run:
@@ -19,6 +20,7 @@ jobs:
           name: Print conda-build environment variables
           command: |
             echo "CONDA_PERL=${CONDA_PERL}"
+            echo "CONDA_PY=${CONDA_PY}"
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./ci_support/run_docker_build.sh
@@ -27,4 +29,4 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build__CONDA_PERL_5.22.2.1
+      - build__CONDA_PERL_5.22.2.1__CONDA_PY_27

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ osx_image: xcode6.4
 env:
   matrix:
     
-    - CONDA_PERL=5.22.2.1
+    - CONDA_PERL=5.22.2.1  CONDA_PY=27
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "N+fypPRXhOp2HiH+EKZO2nje+uZxgU56g0+lD57povGLfU5nVbd5WTvuTGFdyXRGcSLDbJHJBN+Mfrxs1aY4cJmMCClJ9ahxRCBz06anFvzNs8UMzoRBO0ze/FEFrHAmKRh2XZFKCOm5DpqFJT4tIHod5zc+8E2dVH/xswxZ6zhsQKubo8e4pCRCtAdeDe3uZv0g8ClwK9ZgN+71PxC4FF1dtjl4XHren6btn6U+rY+dPKhlOf+IoIEFbyYkbSoCJwpzQDhM7Etxu4bRIscGIwrxDZg7IcFQh80joAyTNW0HHp9e0wSB7eVzRbBq8vrXuo6QuFmH/DMLmTndw03RwhAVUrLgnQU0AHli9fkw3YwTaNWMC0vb61Qnhc7GDbjG0NNUeCrivADjbV3Jx3SP3PMJE/GlyGekFr450Jf5K1AwjkhaZp7eq8NOdn9YgWa/Wri0fHJnLMr8AzSe8LI2nechzGXD59bPAQuPZWVo1yoly3ZE6M+kfqvhuWJ4vYwXl52Mytbwaa6+ofA7vFdRn7gnK2DUce78J7Jg/rqAvN8JxoQfyjR4SRR4WiqDasB4x2dyrZ2o72bh5uOUWWmNHV3Q3fYRav92U3qsg80jvxY2rgRvgeND+IepUQJwFhuTkqe+J3bNBHBy2+ZjAQjTW+ilChLxQmFZJsbNmUulJIg="

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,6 +41,7 @@ cat << EOF | docker run -i \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -e HOST_USER_ID="${HOST_USER_ID}" \
                         -e CONDA_PERL="${CONDA_PERL}" \
+                        -e CONDA_PY="${CONDA_PY}" \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
                         bash || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
 
 requirements:
   build:
-    - python  # [py27]
+    - python
     - glib 2.51.*
     - gobject-introspection 1.51.*
     - perl 5.22.2.1


### PR DESCRIPTION
Appears there was a Python selector on `python`, which caused some issues building the recipe. This drops that selector and re-renders the feedstock. Otherwise the recipe built fine for me locally on both Linux and macOS.