### PR TITLE
Remove gobject-introspection dependency

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,15 +11,15 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_aarch64_:
         CONFIG: linux_aarch64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-aarch64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
       linux_ppc64le_:
         CONFIG: linux_ppc64le_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -9,11 +9,8 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 glib:
 - 2.64.6
 target_platform:
 - linux-64
-zip_keys:
-- - cdt_name
-  - docker_image

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -13,7 +13,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-aarch64
 glib:
 - 2.64.6
 target_platform:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -9,7 +9,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-ppc64le
 glib:
 - 2.64.6
 target_platform:

--- a/recipe/bld_atk.bat
+++ b/recipe/bld_atk.bat
@@ -3,7 +3,7 @@ setlocal EnableDelayedExpansion
 
 :: set pkg-config path so that host deps can be found
 :: (set as env var so it's used by both meson and during build with g-ir-scanner)
-set "PKG_CONFIG_PATH=%LIBRARY_LIB%\pkgconfig;%LIBRARY_PREFIX%\share\pkgconfig"
+set "PKG_CONFIG_PATH=%LIBRARY_LIB%\pkgconfig;%LIBRARY_PREFIX%\share\pkgconfig;%BUILD_PREFIX%\Library\lib\pkgconfig"
 
 :: get mixed path (forward slash) form of prefix so host prefix replacement works
 set "LIBRARY_PREFIX_M=%LIBRARY_PREFIX:\=/%"

--- a/recipe/build_atk.sh
+++ b/recipe/build_atk.sh
@@ -2,6 +2,10 @@
 
 set -ex
 
+# necessary to ensure the gobject-introspection-1.0 pkg-config file gets found
+# meson needs this to determine where the g-ir-scanner script is located
+export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$BUILD_PREFIX/lib/pkgconfig
+
 meson builddir --prefix=$PREFIX --libdir=$PREFIX/lib
 meson configure -D enable_docs=false builddir
 ninja -v -C builddir

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: fb76247e369402be23f1f5c65d38a9639c1164d934e40f6a9cf3c9e96b652788
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win and vc<14]
   run_exports:
     - atk-{{ abi_version }} >={{ version }}
@@ -26,18 +26,16 @@ outputs:
         - atk-{{ abi_version }} >={{ version }}
     requirements:
       build:
-        - make  # [not win]
         - meson
+        - gobject-introspection 1.*
         - ninja
         - python >=3.6
         - pkg-config
         - {{ compiler('c') }}
       host:
         - glib
-        - gobject-introspection 1.*
       run:
-        - glib
-        - gobject-introspection 1.*
+        - libglib
       run_constrained:
         - atk-{{ abi_version }} {{ version }}
 


### PR DESCRIPTION
gobject-introspection is not a run-time dependency, and is only necessary at build time.